### PR TITLE
feat: remove fallback to npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ snpx -y cowsay hello
 
 ### Docker not available
 
-`snpx` falls back to regular npx if Docker is not available.
+`snpx` requires Docker to be installed and running. If Docker is not available, `snpx` will exit with an error.
 
 ## Capability Policy
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,9 @@ async fn main() -> Result<()> {
             .run_containerized_npx_with_flags(&npx_flags, &args.package_args)
             .await
     } else {
-        runner.run_fallback_npx_with_flags(&npx_flags, &args.package_args)
+        eprintln!("Docker is not available or not running");
+        eprintln!("snpx requires Docker to be installed and running");
+        std::process::exit(1);
     };
 
     match result {


### PR DESCRIPTION
change README.md to clarify that Docker is required to run 'snpx'.

Signed-off-by: Jiaxiao Zhou <duibao55328@gmail.com>
